### PR TITLE
Fixed typo (auth.go -> go.auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you plan to use the same `AuthHandler` to secure all of your routes, you may 
     mux.Get("/:param", handler).Secure()
 
 ### OAuth2
-In the above examples, we implemented our own custom `AuthHandler`. Check out the [auth.go](https://github.com/bradrydzewski/auth.go) API which provides custom AuthHandlers for OAuth2 providers such as Google and Github.
+In the above examples, we implemented our own custom `AuthHandler`. Check out the [go.auth](https://github.com/bradrydzewski/go.auth) API which provides custom AuthHandlers for OAuth2 providers such as Google and Github.
 
 ## Logging
 Logging is enabled by default, but can be disabled:


### PR DESCRIPTION
Thanks for open sourcing this. Looks like a useful competitor to [pat](https://github.com/bmizerany/pat).
