### PR TITLE
Apply filters only to given path prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can, for example, filter all request to enforce some type of security:
 You can also apply filters only when certain REST URL Parameters exist:
 
     r.Get("/:id", handler)
-    r.Filter("id", func(rw http.ResponseWriter, r *http.Request) {
+    r.FilterParam("id", func(rw http.ResponseWriter, r *http.Request) {
 		...
 	})
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ You can also apply filters only when certain REST URL Parameters exist:
 		...
 	})
 
+Or apply filters only when URL begins with a given path:
+
+    r.Get("/hello/:name", handler)
+    r.FilterPath("/hello", func(rw http.ResponseWriter, r *http.Request) {
+        ...
+    })
+
 ## Helper Functions
 You can use helper functions for serializing to Json and Xml. I found myself constantly writing code to serialize, set content type, content length, etc. Feel free to use these functions to eliminate redundant code in your app.
 

--- a/routes.go
+++ b/routes.go
@@ -138,13 +138,24 @@ func (m *RouteMux) Filter(filter http.HandlerFunc) {
 
 // FilterParam adds the middleware filter iff the REST URL parameter exists.
 func (m *RouteMux) FilterParam(param string, filter http.HandlerFunc) {
-	if !strings.HasPrefix(param,":") {
-		param = ":"+param
+	if !strings.HasPrefix(param, ":") {
+		param = ":" + param
 	}
 
 	m.Filter(func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Query().Get(param)
-		if len(p) > 0 { filter(w, r) }
+		if len(p) > 0 {
+			filter(w, r)
+		}
+	})
+}
+
+// FilterPath adds the middleware filter iff the REST URL begins with given path.
+func (m *RouteMux) FilterPath(path string, filter http.HandlerFunc) {
+	m.Filter(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, path) {
+			filter(w, r)
+		}
 	})
 }
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -148,6 +148,36 @@ func TestFilterParam(t *testing.T) {
 
 }
 
+// TestFilterPath tests the ability to apply middleware
+// function to filter all routes beginning with specified
+// path in the REST url
+func TestFilterPath(t *testing.T) {
+
+	r, _ := http.NewRequest("GET", "/foo", nil)
+	w := httptest.NewRecorder()
+
+	// first test that the param filter does not trigger
+	handler := new(RouteMux)
+	handler.Get("/foo", HandlerOk)
+	handler.Get("/bar", HandlerOk)
+	handler.FilterPath("/bar", HandlerErr)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Code set to [%v]; want [%v]", w.Code, http.StatusOK)
+	}
+
+	// now test the path filter does trigger
+	r, _ = http.NewRequest("GET", "/bar", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Did not apply Path Filter. Code set to [%v]; want [%v]", w.Code, http.StatusBadRequest)
+	}
+
+}
+
 // Benchmark_RoutedHandler runs a benchmark against
 // the RouteMux using the default settings.
 func Benchmark_RoutedHandler(b *testing.B) {


### PR DESCRIPTION
Example:

```
r.FilterPath("/foo", ...)
r.Get("/foo/bar", ...) // Filter applied
r.Get("/baz/qux", ...) // Filter not applied
```
