### PR TITLE
routes.FilterPrefixPath()

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -99,7 +99,7 @@ func (m *RouteMux) AddRoute(method string, pattern string, handler http.HandlerF
 		if strings.HasPrefix(part, ":") {
 			expr := "([^/]+)"
 			//a user may choose to override the defult expression
-			// similar to expressjs: ‘/user/:id([0-9]+)’ 
+			// similar to expressjs: ‘/user/:id([0-9]+)’
 			if index := strings.Index(part, "("); index != -1 {
 				expr = part[index:]
 				part = part[:index]
@@ -138,13 +138,24 @@ func (m *RouteMux) Filter(filter http.HandlerFunc) {
 
 // FilterParam adds the middleware filter iff the REST URL parameter exists.
 func (m *RouteMux) FilterParam(param string, filter http.HandlerFunc) {
-	if !strings.HasPrefix(param,":") {
-		param = ":"+param
+	if !strings.HasPrefix(param, ":") {
+		param = ":" + param
 	}
 
 	m.Filter(func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Query().Get(param)
-		if len(p) > 0 { filter(w, r) }
+		if len(p) > 0 {
+			filter(w, r)
+		}
+	})
+}
+
+// FilterParam adds the middleware filter if the prefix path exists.
+func (m *RouteMux) FilterPrefixPath(path string, filter http.HandlerFunc) {
+	m.Filter(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, path) {
+			filter(w, r)
+		}
 	})
 }
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -171,6 +171,7 @@ func TestFilterPrefixPath(t *testing.T) {
 	// first test that the prefix path filter does not trigger
 	handler := new(RouteMux)
 	handler.Get("/prefix", HandlerOk)
+	handler.Get("/prefix/mypath", HandlerOk) //prefix is the base bath
 	handler.Get("/someotherprefix", HandlerErr)
 	handler.FilterPrefixPath("/prefix", FilterPrefixPath)
 	handler.ServeHTTP(w, r)
@@ -188,6 +189,17 @@ func TestFilterPrefixPath(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Did not apply Prefix path Filter. Code set to [%v]; want [%v]", w.Code, http.StatusOK)
+	}
+
+	// test ok for /prefix as base path
+	r, _ = http.NewRequest("GET", "/prefix/mypath", nil)
+	r.Header.Set("Token", "mytoken")
+	r.Header.Set("Secret", "mysecret")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Did not apply Prefix base path Filter. Code set to [%v]; want [%v]", w.Code, http.StatusOK)
 	}
 
 	//test when secret is incorrect


### PR DESCRIPTION
The function is called when a prefix path is found in the route. Useful for base path authentication. For e.g: In path "/prefix/mypath", apply common authentication for base path, "/prefix". Please see `routes_test.go` for for information
