### PR TITLE
Parameters specified in the routes themselves are never decoded

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -183,7 +183,12 @@ func (m *RouteMux) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			//add url parameters to the query param map
 			values := r.URL.Query()
 			for i, match := range matches[1:] {
-				values.Add(route.params[i], match)
+				value, err := url.QueryUnescape(match)
+				if err != nil {
+					values.Add(route.params[i], match)
+				} else {
+					values.Add(route.params[i], value)
+				}
 			}
 
 			//reassemble query params and add to RawQuery


### PR DESCRIPTION
This commit makes parameters within a URL be decoded, just like the regular query parameters. For example, the route "/test/:name/foo" and the path: "/test/Test+User/foo" should result in the string "Test User" for the ":name" key, not "Test+User".

This patch applies that, and in an attempt to keep it from choking on invalid escapes, it defaults back to the original match if QueryUnescape fails. This is my preferred behavior, but doesn't necessarily match what your vision for how this project was meant to process that type of failure.
